### PR TITLE
Make minitest-bang more compatible with RSpec's let!

### DIFF
--- a/lib/minitest/bang.rb
+++ b/lib/minitest/bang.rb
@@ -5,11 +5,7 @@ module Minitest
   module Bang
     def before_setup
       super
-      return if self.class.before_ran
-      self.class.bangs.each do |bang|
-        send(bang)
-      end
-
+      self.class.all_bangs.each(&method(:send))
     end
   end
 

--- a/lib/minitest/bang.rb
+++ b/lib/minitest/bang.rb
@@ -5,9 +5,11 @@ module Minitest
   module Bang
     def before_setup
       super
+      return if self.class.before_ran
       self.class.bangs.each do |bang|
         send(bang)
       end
+
     end
   end
 

--- a/lib/minitest/dsl.rb
+++ b/lib/minitest/dsl.rb
@@ -3,21 +3,52 @@ require 'minitest/spec'
 
 module Minitest
   module Spec::DSL
-    def bangs
-      @bangs ||= Set.new
-      @bangs = @bangs + bangs_from_parent_scope
+    def before_bangs
+      @before_bangs ||= Set.new
+    end
+    def after_bangs
+      @after_bangs ||= Set.new
+    end
+    def before_ran
+      @before_ran
     end
 
     def let!(name, &block)
       let(name, &block)
-      bangs << name
+      if @before_ran
+        after_bangs << name
+      else
+        before_bangs << name
+      end
     end
 
-    private
+    def before_with_bangs(_type=nil, &block)
+      @before_ran = true
+      b0 = before_bangs
+      b1 = after_bangs
+      block_with_bangs = ->(x) do
+        b0.each do |bang|
+          send(bang)
+        end
+        self.instance_eval(&block)
+        b1.each do |bang|
+          send(bang)
+        end
+      end
+      before_without_bangs(_type, &block_with_bangs)
+    end
+
+    alias_method :before_without_bangs, :before
+    alias_method :before, :before_with_bangs
+
+    def bangs
+      before_bangs + after_bangs + bangs_from_parent_scope
+    end
 
     def bangs_from_parent_scope
       return Set.new unless defined? self.superclass.bangs
       self.superclass.bangs
     end
+
   end
 end

--- a/lib/minitest/dsl.rb
+++ b/lib/minitest/dsl.rb
@@ -4,13 +4,20 @@ require 'minitest/spec'
 module Minitest
   module Spec::DSL
 
-    def bangs
-      @bangs ||= Set.new
-    end
-
     def let!(name, &block)
       let(name, &block)
       bangs << name
+    end
+
+    def all_bangs
+      return Set.new if @before_ran
+      bangs + bangs_from_parent_scope
+    end
+
+    private
+
+    def bangs
+      @bangs ||= Set.new
     end
 
     def before_with_bangs(_type=nil, &block)
@@ -31,11 +38,6 @@ module Minitest
 
     alias_method :before_without_bangs, :before
     alias_method :before, :before_with_bangs
-
-    def all_bangs
-      return Set.new if @before_ran
-      bangs + bangs_from_parent_scope
-    end
 
     def bangs_from_parent_scope
       return Set.new unless defined? self.superclass.all_bangs

--- a/lib/minitest/dsl.rb
+++ b/lib/minitest/dsl.rb
@@ -3,52 +3,43 @@ require 'minitest/spec'
 
 module Minitest
   module Spec::DSL
-    def before_bangs
-      @before_bangs ||= Set.new
-    end
-    def after_bangs
-      @after_bangs ||= Set.new
-    end
-    def before_ran
-      @before_ran
+
+    def bangs
+      @bangs ||= Set.new
     end
 
     def let!(name, &block)
       let(name, &block)
-      if @before_ran
-        after_bangs << name
-      else
-        before_bangs << name
-      end
+      bangs << name
     end
 
     def before_with_bangs(_type=nil, &block)
       @before_ran = true
-      b0 = before_bangs
-      b1 = after_bangs
-      block_with_bangs = ->(x) do
-        b0.each do |bang|
-          send(bang)
-        end
-        self.instance_eval(&block)
-        b1.each do |bang|
-          send(bang)
-        end
+
+      before_bangs = Set.new(bangs + bangs_from_parent_scope)
+      bangs.clear
+      after_bangs = bangs
+
+      block_with_bangs = ->(arg) do
+        before_bangs.each(&method(:send))
+        self.instance_exec(arg, &block)
+        after_bangs.each(&method(:send))
       end
+
       before_without_bangs(_type, &block_with_bangs)
     end
 
     alias_method :before_without_bangs, :before
     alias_method :before, :before_with_bangs
 
-    def bangs
-      before_bangs + after_bangs + bangs_from_parent_scope
+    def all_bangs
+      return Set.new if @before_ran
+      bangs + bangs_from_parent_scope
     end
 
     def bangs_from_parent_scope
-      return Set.new unless defined? self.superclass.bangs
-      self.superclass.bangs
+      return Set.new unless defined? self.superclass.all_bangs
+      self.superclass.all_bangs
     end
-
   end
 end

--- a/test/bang_test.rb
+++ b/test/bang_test.rb
@@ -130,6 +130,29 @@ describe Minitest::Spec, :let! do
     specify { @order.must_equal [:let, :before] }
   end
 
+  describe "lots of random let and before blocks" do
+    let!(:let1) { append_symbol(:let1) }
+    let!(:let2) { append_symbol(:let2) }
+
+    before do
+      append_symbol(:before1)
+    end
+
+    let!(:let3) { append_symbol(:let3) }
+
+    describe "inner" do
+      let!(:let4) { append_symbol(:let4) }
+
+      before do
+        append_symbol(:before2)
+      end
+
+      let!(:let5) { append_symbol(:let5) }
+
+      specify { @order.must_equal [:let1, :let2, :before1, :let3, :let4, :before2, :let5] }
+    end
+  end
+
   def append_symbol(symbol)
     @order ||= []
     @order << symbol

--- a/test/bang_test.rb
+++ b/test/bang_test.rb
@@ -89,4 +89,49 @@ describe Minitest::Spec, :let! do
       end
     end
   end
+
+  describe "nested describes with before blocks" do
+    let!(:top_let) { append_symbol(:top_let) }
+
+    before do
+      append_symbol(:top_before)
+    end
+
+    specify { @order.must_equal [:top_let, :top_before] }
+
+    describe "nested" do
+      let!(:nested_let) { append_symbol(:nested_let) }
+
+      before do
+        append_symbol(:nested_before)
+      end
+
+      specify { @order.must_equal [:top_let, :top_before, :nested_let, :nested_before] }
+    end
+  end
+
+  describe "before then let" do
+    before do
+      append_symbol(:before)
+    end
+
+    let!(:let) { append_symbol(:let) }
+
+    specify { @order.must_equal [:before, :let] }
+  end
+
+  describe "let then before" do
+    let!(:let) { append_symbol(:let) }
+
+    before do
+      append_symbol(:before)
+    end
+
+    specify { @order.must_equal [:let, :before] }
+  end
+
+  def append_symbol(symbol)
+    @order ||= []
+    @order << symbol
+  end
 end


### PR DESCRIPTION
This PR is to solve #5 and make minitest-bang behave more similarly to RSpec's let!. I wrote a few tests that were as similar as possible in both MiniTest and RSpec. The RSpec ones passed and the MiniTest ones failed.

This still needs to be refactored before merging. But all tests are now passing. It also unfortunately (but necessarily) avoids most of the built in hooks that MiniTest provides for extensibility. There's also a few more tests I'll probably write before merging.